### PR TITLE
:sparkles: Feat: 개인 ToDo 수정 기능 (#23)

### DIFF
--- a/templates/todos/todo_detail.html
+++ b/templates/todos/todo_detail.html
@@ -11,6 +11,12 @@
   <main>
     <h2>Detail</h2>
 
+    <a href="{% url 'todo_list' %}">목록</a>
+    {% if todo.study %}
+    {% else %}
+    <a href="{% url 'personal_todo_edit' todo.pk %}">수정</a>
+    {% endif %}
+
     <ul>
       {% if todo.study %}
       <li>

--- a/todos/tests/test_views.py
+++ b/todos/tests/test_views.py
@@ -297,3 +297,85 @@ class PersonalToDoCreateTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(ToDo.objects.count(), 0)
         self.assertEqual(ToDoAssignee.objects.count(), 0)
+
+
+class PersonalToDoUpdateTest(TestCase):
+    """
+    개인 할 일 수정 테스트
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        test_user = User.objects.create_user(
+            nickname="testuser", email="testuser@example.com", password="3HJ1vRV0Z&2iD"
+        )
+        test_user.save()
+
+        todo = ToDo.objects.create(
+            title="Test ToDo",
+            content="Test Content",
+            start_at=timezone.now(),
+            end_at=timezone.now() + timezone.timedelta(days=1),
+            status="ToDo",
+            alert_set="없음",
+        )
+
+        todo.todo_assignees.create(assignee=test_user)
+
+    def test_redirect_if_not_logged_in(self):
+        """
+        로그인 안 했을 때 로그인 페이지로 리다이렉트 되는지 확인
+        """
+        response = self.client.get(reverse("personal_todo_edit", args=[1]))
+        self.assertRedirects(response, "/accounts/login/?next=/todos/personal/edit/1/")
+
+    def test_logged_in_uses_correct_template(self):
+        """
+        로그인 했을 때 올바른 템플릿인지 확인
+        """
+        login = self.client.login(
+            email="testuser@example.com", password="3HJ1vRV0Z&2iD"
+        )
+        response = self.client.get(reverse("personal_todo_edit", args=[1]))
+
+        self.assertTemplateUsed(response, "todos/todo_form.html")
+
+    def test_edit_todo(self):
+        login = self.client.login(
+            email="testuser@example.com", password="3HJ1vRV0Z&2iD"
+        )
+        response = self.client.get(reverse("personal_todo_edit", args=[1]))
+
+        response = self.client.post(
+            reverse("personal_todo_edit", args=[1]),
+            {
+                "title": "test2",
+                "content": "test2",
+                "status": "ToDo",
+                "alert_set": "없음",
+            },
+        )
+
+        # 할 일 수정 성공
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(ToDo.objects.count(), 1)
+        self.assertEqual(ToDoAssignee.objects.count(), 1)
+        self.assertEqual(ToDo.objects.get().title, "test2")
+
+    def test_edit_todo_access_fail(self):
+        """
+        다른 사용자가 할 일 수정에 접근할 때 403 응답을 받는지 확인
+        """
+        test_user2 = User.objects.create_user(
+            nickname="testuser2",
+            email="testuser2@example.com",
+            password="3HJ1vRV0Z&2iD",
+        )
+        test_user2.save()
+
+        login = self.client.login(
+            email="testuser2@example.com", password="3HJ1vRV0Z&2iD"
+        )
+        response = self.client.get(reverse("personal_todo_edit", args=[1]))
+
+        self.assertEqual(response.status_code, 403)

--- a/todos/urls.py
+++ b/todos/urls.py
@@ -10,4 +10,9 @@ urlpatterns = [
         views.PersonalToDoCreate.as_view(),
         name="personal_todo_create",
     ),
+    path(
+        "personal/edit/<int:pk>/",
+        views.PersonalToDoUpdate.as_view(),
+        name="personal_todo_edit",
+    ),
 ]

--- a/todos/views.py
+++ b/todos/views.py
@@ -1,8 +1,8 @@
 from django.urls import reverse_lazy
 from django.views.generic import ListView
 from django.views.generic.detail import DetailView
-from django.views.generic.edit import CreateView
-from django.contrib.auth.mixins import LoginRequiredMixin
+from django.views.generic.edit import CreateView, UpdateView
+from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 
 from .models import ToDo
 from .forms import PersonalToDoForm
@@ -58,3 +58,17 @@ class PersonalToDoCreate(LoginRequiredMixin, CreateView):
         todo.save()
         todo.todo_assignees.create(assignee=self.request.user)
         return super().form_valid(form)
+
+
+class PersonalToDoUpdate(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
+    """
+    개인 할 일 수정
+    """
+
+    model = ToDo
+    form_class = PersonalToDoForm
+    success_url = reverse_lazy("personal_todo_list")
+
+    def test_func(self):
+        todo = self.get_object()
+        return todo.todo_assignees.filter(assignee=self.request.user).exists()


### PR DESCRIPTION
1. 추가한 기능
   - 개인 할 일 추가 로직
   - 개인 할 일 추가 테스트 코드
2. 기능 설명
   2.1 개인 할 일 추가 로직 
     - `todos/personal/edit/<int:pk>`로 접근
     - `todos_form` 템플릿 활용
     - 할당된 사람 이외의 사용자는 접근이 허용되지 않도록 설정

   2.2 개인 할 일 추가 테스트
     - 할 일 수정 성공 확인
     - 다른 사용자가 할 일 수정에 접근할 때 403 응답을 받는지 확인
3. 비고
   - detail뷰에서 study가 없는경우 `personal_todo_edit`으로 이동하여 수정 가능