### PR TITLE
:sparkles: Feat: 사용자 정보 수정 기능 개발

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -192,3 +192,50 @@ class CustomLoginForm(AuthenticationForm):
             except User.DoesNotExist:
                 raise forms.ValidationError("존재하지 않는 사용자이거나 비밀번호가 일치하지 않습니다.")
         return super().clean()
+
+
+class AccountUpdateForm(forms.ModelForm):
+    nickname = forms.CharField(
+        required=True,
+        error_messages={
+            "required": "닉네임을 입력해주세요.",
+            "unique": "중복된 닉네임입니다.",
+        },
+    )
+
+    development_field = forms.ChoiceField(
+        required=True,
+        choices=User.DEVELOPMENT_FIELD_CHOICES,
+        error_messages={
+            "invalid_choice": "항목에 포함된 개발 분야를 선택해주세요.",
+            "required": "개발 분야를 선택해주세요.",
+        },
+    )
+
+    class Meta:
+        model = User
+        fields = [
+            "nickname",
+            "development_field",
+            "content",
+            "profile_image",
+        ]
+        widgets = {
+            "email": forms.EmailInput(attrs={"readonly": True}),
+        }
+
+    def clean_nickname(self):
+        """
+        닉네임 유효성 검사 메서드
+            - 닉네임 길이가 2자리 이상, 15자리 이하인지 검사
+            - 닉네임에 특수문자가 포함되어 있는지 검사
+        """
+        # 닉네임 길이가 2자리 이상, 15자리 이하인지 검사
+        nickname = self.cleaned_data.get("nickname")
+        if len(nickname) < 2 or len(nickname) > 15:
+            raise forms.ValidationError("닉네임은 2자리 이상, 15자리 이하로 입력해주세요.")
+        # 닉네임에 특수문자가 포함되어 있는지 검사
+        if any(char in nickname for char in "~!@#$%^&*()_+"):
+            raise forms.ValidationError("닉네임에 특수문자를 포함할 수 없습니다.")
+
+        return nickname

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -7,7 +7,8 @@ urlpatterns = [
     path("email_confirm/<str:token>/", views.email_confirm, name="email_confirm"),
     path("social/signup/", views.social_signup, name="social_signup"),
     path("logout/", views.logout, name="logout"),
-    path("", include("allauth.urls")),
-    path("custom_login/", views.login, name="login"),
+    path("login/", views.login, name="login"),
     path("profile/<int:pk>/", views.profile, name="profile"),
+    path("edit/", views.account_update, name="account_update"),
+    path("", include("allauth.urls")),
 ]


### PR DESCRIPTION
1. 추가한 기능
- 로그인한 사용자를 대상으로 본인의 사용자 정보를 수정하는 기능

2. 테스트 명령어
- `python manage.py test accounts.tests.TestAccount.test_account_update`

3. 테스트 항목 - 사용자 정보 수정 테스트
- 로그인하지 않은 사용자의 사용자 정보 수정 테스트
- 정상 사용자 정보 수정 테스트
- 닉네임 유효성 테스트
	- 닉네임이 1자리일 경우
	- 닉네임이 16자리 이상일 경우
	- 닉네임에 특수문자가 있을 경우
	- 닉네임이 비어있을 경우
	- 중복된 닉네임일 경우
- 개발 분야 유효성 테스트
	- 개발 분야가 비어있을 경우
	- 개발 항목에 없는 분야일 경우

4. 비고
- 금일 스크럼시 결정됐던 URL의 변경 코드도 포함하여 commit하였습니다.