### PR TITLE
:sparkles: Feat: Studies 앱 멤버 관리(가입, 멤버 추방, 리더 양도)

### DIFF
--- a/studies/forms.py
+++ b/studies/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from .models import Study, Comment, Recomment, Tag, Category
+from .models import Study, Comment, Recomment, Tag, Category, Blacklist
 import datetime
 
 

--- a/studies/urls.py
+++ b/studies/urls.py
@@ -66,7 +66,12 @@ urlpatterns = [
     ),
     path(
         "<int:pk>/studymember/<int:studymember_id>/manager/",
-        views.UpdateStudyMember.as_view(),
+        views.DelegateAuthorityView.as_view(),
         name="change_study_manager",
+    ),
+    path(
+        "<int:pk>/studymember/delete/",
+        views.WithdrawStudy.as_view(),
+        name="withdraw_study",
     ),
 ]

--- a/studies/urls.py
+++ b/studies/urls.py
@@ -38,4 +38,35 @@ urlpatterns = [
         views.RecommentDelete.as_view(),
         name="recomment_delete",
     ),
+    path("<int:pk>/apply/", views.apply_study_join, name="apply_study_join"),
+    path(
+        "studymember/<int:studymember_id>/approve/",
+        views.approve_study_join,
+        name="approve_study_join",
+    ),
+    path(
+        "studymember/<int:studymember_id>/reject/",
+        views.reject_study_join,
+        name="reject_study_join",
+    ),
+    path(
+        "<int:pk>/studymember/apply/list/",
+        views.ApproveStudyJoinDetail.as_view(),
+        name="study_member_apply_list",
+    ),
+    path(
+        "<int:pk>/studymember/list/",
+        views.ManageStudyMemberList.as_view(),
+        name="study_member_list",
+    ),
+    path(
+        "<int:pk>/studymember/<int:studymember_id>/delete/",
+        views.DeleteStudyMember.as_view(),
+        name="delete_study_member",
+    ),
+    path(
+        "<int:pk>/studymember/<int:studymember_id>/manager/",
+        views.UpdateStudyMember.as_view(),
+        name="change_study_manager",
+    ),
 ]

--- a/studies/views.py
+++ b/studies/views.py
@@ -6,9 +6,11 @@ from django.views.generic import (
     UpdateView,
     DeleteView,
 )
+from django.shortcuts import redirect
 from django.urls import reverse_lazy
 from .forms import StudyForm, CommentForm, RecommentForm
 from django.db.models import Q
+from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.contrib.auth import get_user_model
 from django.shortcuts import get_object_or_404
@@ -77,6 +79,15 @@ class StudyDetail(DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        context["StudyLeader"] = StudyMember.objects.get(
+            study=self.object, is_manager=True, is_accepted=True
+        )
+        context["StudyMembers"] = StudyMember.objects.filter(
+            study=self.object, is_accepted=True
+        )
+        context["StudyAppliers"] = StudyMember.objects.filter(
+            study=self.object, is_accepted=False
+        )
         return context
 
     def get_object(self, queryset=None):
@@ -255,3 +266,164 @@ class RecommentDelete(UserPassesTestMixin, DeleteView):
         return reverse_lazy(
             "studies:study_detail", kwargs={"pk": self.object.comment.study.pk}
         )
+
+
+class ApproveStudyJoinDetail(UserPassesTestMixin, DetailView):
+    """
+    스터디 가입 승인
+    스터디 생성자만이 스터디 가입을 승인할 수 있습니다.
+    스터디 생성자가 스터디 가입을 승인하면 studymember 모델의 is_accept를 True로, is_manager를 False로 지정합니다.
+    """
+
+    model = StudyMember, Study
+    template_name = "studies/approve_study_join.html"
+
+    def get_object(self, queryset=None):
+        return get_object_or_404(Study, pk=self.kwargs["pk"])
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["StudyLeader"] = StudyMember.objects.get(
+            study=self.object, is_manager=True
+        )
+        context["StudyMembers"] = StudyMember.objects.filter(
+            study=self.object, is_accepted=False
+        )
+        return context
+
+    def test_func(self):
+        study = self.get_object()
+        studyleader = StudyMember.objects.get(study=study, is_manager=True)
+        return studyleader.user == self.request.user
+
+
+class ManageStudyMemberList(UserPassesTestMixin, DetailView):
+    """
+    스터디 멤버 관리 리스트 조회
+    스터디 생성자만이 리스트를 조회할 수 있습니다.
+    """
+
+    model = StudyMember, Study
+    template_name = "studies/manage_study_member.html"
+
+    def get_object(self, queryset=None):
+        return get_object_or_404(Study, pk=self.kwargs["pk"])
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["StudyLeader"] = StudyMember.objects.get(
+            study=self.object, is_manager=True
+        )
+        context["StudyMembers"] = StudyMember.objects.filter(
+            study=self.object, is_accepted=True
+        )
+        return context
+
+    def test_func(self):
+        study = self.get_object()
+        studyleader = StudyMember.objects.get(study=study, is_manager=True)
+        return studyleader.user == self.request.user
+
+
+class DeleteStudyMember(UserPassesTestMixin, DeleteView):
+    """
+    스터디 멤버 삭제
+    스터디 생성자만이 스터디 멤버를 삭제할 수 있습니다.
+    """
+
+    model = StudyMember
+
+    def get_object(self, queryset=None):
+        return get_object_or_404(StudyMember, pk=self.kwargs["studymember_id"])
+
+    def test_func(self):
+        studymember = self.get_object()
+        studyleader = StudyMember.objects.get(study=studymember.study, is_manager=True)
+        return studyleader.user == self.request.user
+
+    def get_success_url(self):
+        return reverse_lazy(
+            "studies:study_member_list", kwargs={"pk": self.object.study.pk}
+        )
+
+
+class UpdateStudyMember(UserPassesTestMixin, UpdateView):
+    """
+    스터디 멤버 수정
+    스터디 생성자만이 스터디 멤버를 수정할 수 있습니다.
+    요청한 유저에게 is_manager를 True로 지정하는 동시에 스터디 생성자의 is_manager를 False로 지정합니다.
+    """
+
+    model = StudyMember
+    fields = ["is_manager", "is_accepted"]
+
+    def get_object(self, queryset=None):
+        return get_object_or_404(StudyMember, pk=self.kwargs["studymember_id"])
+
+    def test_func(self):
+        studymember = self.get_object()
+        studyleader = StudyMember.objects.get(study=studymember.study, is_manager=True)
+        return studyleader.user == self.request.user
+
+    def form_valid(self, form):
+        studymember = self.get_object()
+        studyleader = StudyMember.objects.get(study=studymember.study, is_manager=True)
+        studyleader.is_manager = False
+        studyleader.save()
+        return super().form_valid(form)
+
+    def get_success_url(self):
+        return reverse_lazy("studies:study_detail", kwargs={"pk": self.object.study.pk})
+
+
+@login_required
+def apply_study_join(request, pk):
+    """
+    스터디 가입 신청
+    스터디 가입 신청 시 studymember 모델의 user를 로그인한 유저로 지정합니다.
+    1번 신청이 된 스터디는 다시 승인 혹은 취소 전까지 신청할 수 없습니다.
+    """
+    study = get_object_or_404(Study, pk=pk)
+    studymember = StudyMember.objects.filter(study=study, user=request.user)
+    if studymember:
+        return redirect("studies:study_detail", pk=pk)
+
+    StudyMember.objects.create(study=study, user=request.user)
+
+    return redirect("studies:study_detail", pk=pk)
+
+
+@login_required
+def approve_study_join(request, studymember_id):
+    """
+    스터디 가입 승인
+    스터디 생성자만이 스터디 가입을 승인할 수 있습니다.
+    스터디 생성자가 스터디 가입을 승인하면 studymember 모델의 is_accept를 True로, is_manager를 False로 지정합니다.
+    """
+    studymember = get_object_or_404(StudyMember, id=studymember_id)
+    studyleader = StudyMember.objects.get(study=studymember.study, is_manager=True)
+    if request.user != studyleader.user:
+        return redirect("studies:study_detail", pk=studymember.study.pk)
+
+    studymember.is_accepted = True
+    studymember.is_manager = False
+    studymember.save()
+
+    return redirect("studies:study_detail", pk=studymember.study.pk)
+
+
+@login_required
+def reject_study_join(request, studymember_id):
+    """
+    스터디 가입 거절
+    스터디 생성자만이 스터디 가입을 거절할 수 있습니다.
+    스터디 생성자가 스터디 가입을 거절하면 studymember 모델을 삭제합니다.
+    """
+    studymember = get_object_or_404(StudyMember, id=studymember_id)
+    studyleader = StudyMember.objects.get(study=studymember.study, is_manager=True)
+    if request.user != studyleader.user:
+        return redirect("studies:study_detail", pk=studymember.study.pk)
+
+    studymember.delete()
+
+    return redirect("studies:study_detail", pk=studymember.study.pk)

--- a/templates/studies/approve_study_join.html
+++ b/templates/studies/approve_study_join.html
@@ -8,7 +8,7 @@
     </head>
     <body>
         <h1>가입 신청 리스트</h1>
-        {% for studymember in StudyMembers %}
+        {% for studymember in study_members %}
         <div style="display:flex; gap:10px;">
             <span>{{ studymember.user }}</span>
             <form action="{% url 'studies:approve_study_join' studymember.id %}" method="POST">

--- a/templates/studies/approve_study_join.html
+++ b/templates/studies/approve_study_join.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="ko-KR">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>DeVtail</title>
+    </head>
+    <body>
+        <h1>가입 신청 리스트</h1>
+        {% for studymember in StudyMembers %}
+        <div style="display:flex; gap:10px;">
+            <span>{{ studymember.user }}</span>
+            <form action="{% url 'studies:approve_study_join' studymember.id %}" method="POST">
+                {% csrf_token %}
+                <input type="submit" value="Approve">
+            </form>
+            <form action="{% url 'studies:reject_study_join' studymember.id %}" method="POST">
+                {% csrf_token %}
+                <input type="submit" value="Reject">
+            </form>
+        </div>
+        {% endfor %}
+    </body>
+</html>

--- a/templates/studies/manage_study_member.html
+++ b/templates/studies/manage_study_member.html
@@ -8,7 +8,7 @@
     </head>
     <body>
     <h1>멤버 관리 리스트</h1>
-    {% for studymember in StudyMembers %}
+    {% for studymember in study_members %}
     <div style="display:flex; gap:10px;">
         <span>{{ studymember.user }}</span>
         {% if studymember.is_manager %}
@@ -20,8 +20,6 @@
         </form>
         <form action="{% url 'studies:change_study_manager' study.id studymember.id %}" method="POST">
             {% csrf_token %}
-            <input type="hidden" name="is_accepted" value="True">
-            <input type="hidden" name="is_manager" value="True">
             <input type="submit" value="리더 위임">
         </form>
         {% endif %}

--- a/templates/studies/manage_study_member.html
+++ b/templates/studies/manage_study_member.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="ko-KR">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>DeVtail</title>
+    </head>
+    <body>
+    <h1>멤버 관리 리스트</h1>
+    {% for studymember in StudyMembers %}
+    <div style="display:flex; gap:10px;">
+        <span>{{ studymember.user }}</span>
+        {% if studymember.is_manager %}
+        <span>리더</span>
+        {% else %}
+        <form action="{% url 'studies:delete_study_member' study.id studymember.id %}" method="POST">
+            {% csrf_token %}
+            <input type="submit" value="내보내기">
+        </form>
+        <form action="{% url 'studies:change_study_manager' study.id studymember.id %}" method="POST">
+            {% csrf_token %}
+            <input type="hidden" name="is_accepted" value="True">
+            <input type="hidden" name="is_manager" value="True">
+            <input type="submit" value="리더 위임">
+        </form>
+        {% endif %}
+    </div>
+    {% endfor %}
+
+    </body>
+</html>

--- a/templates/studies/study_detail.html
+++ b/templates/studies/study_detail.html
@@ -9,6 +9,8 @@
     <body>
         <!-- 스터디 상세 페이지 -->
         <h1>Study Detail</h1>
+        <h2>스터디 그룹의 리더 : {{ StudyLeader.user }}</h2>
+        <h2>현재 로그인한 사용자 : {{ user }}</h2>
         <h2>{{ study.category }}</h2>
         {% for tag in study.tags.all %}
         <a href="{% url 'studies:study_list' %}?q={{ tag }}">#{{ tag }} </a>
@@ -19,16 +21,40 @@
         <p>{{ study.created_at }}</p>
         <p>{{ study.updated_at }}</p>
         
+        {% for member in StudyMembers %}
+        <!-- 스터디 그룹 리더일 경우에만 표시 -->
+        {% if user == member.user and member.is_manager %}
         <form action="{% url 'studies:study_update' study.id %}" method="GET">
             {% csrf_token %}
-            <input type="submit" value="Update">
+            <input type="submit" value="수정">
         </form>
         <form action="{% url 'studies:study_delete' study.id %}" method="POST">
             {% csrf_token %}
-            <input type="submit" value="Delete">
+            <input type="submit" value="삭제">
         </form>
+        <!-- 스터디 그룹 리더만 접속 가능한 가입 신청 리스트 페이지 이동 링크 -->
+        <a href="{% url 'studies:study_member_apply_list' study.id %}">가입 신청 리스트</a>
+        <a href="{% url 'studies:study_member_list' study.id %}">멤버 관리 리스트</a>
+        {% endif %}
+        
+        <!-- 스터디 그룹 리더가 아닌 기본 스터디 그룹 멤버일 경우에만 표시 -->
+        {% if user == member.user and not member.is_manager %}
+        <form action="" method="POST">
+            {% csrf_token %}
+            <input type="submit" value="스터디 탈퇴">
+        </form>
+        {% endif %}
+        {% endfor %}
 
-        <a href="{% url 'studies:study_list' %}">Study List</a>
+        <!-- 로그인한 유저이고 스터디 멤버가 아닌 경우에만 표시 -->
+        {% if user not in StudyMembers %}
+        <form action="{% url 'studies:apply_study_join' study.id %}" method="POST">
+            {% csrf_token %}
+            <input type="submit" value="가입 신청">
+        </form>
+        {% endif %}
+
+        <a href="{% url 'studies:study_list' %}">목록으로</a>
 
         <!-- 댓글 리스트 -->
         <h2>Comment List</h2>

--- a/templates/studies/study_detail.html
+++ b/templates/studies/study_detail.html
@@ -9,7 +9,7 @@
     <body>
         <!-- 스터디 상세 페이지 -->
         <h1>Study Detail</h1>
-        <h2>스터디 그룹의 리더 : {{ StudyLeader.user }}</h2>
+        <h2>스터디 그룹의 리더 : {{ study_leader.user }}</h2>
         <h2>현재 로그인한 사용자 : {{ user }}</h2>
         <h2>{{ study.category }}</h2>
         {% for tag in study.tags.all %}
@@ -21,9 +21,9 @@
         <p>{{ study.created_at }}</p>
         <p>{{ study.updated_at }}</p>
         
-        {% for member in StudyMembers %}
+        {% for studymember in study_members %}
         <!-- 스터디 그룹 리더일 경우에만 표시 -->
-        {% if user == member.user and member.is_manager %}
+        {% if user == studymember.user and studymember.is_manager %}
         <form action="{% url 'studies:study_update' study.id %}" method="GET">
             {% csrf_token %}
             <input type="submit" value="수정">
@@ -38,21 +38,22 @@
         {% endif %}
         
         <!-- 스터디 그룹 리더가 아닌 기본 스터디 그룹 멤버일 경우에만 표시 -->
-        {% if user == member.user and not member.is_manager %}
-        <form action="" method="POST">
+        {% if user == studymember.user and not studymember.is_manager %}
+        <form action="{% url 'studies:withdraw_study' study.id %}" method="POST">
             {% csrf_token %}
             <input type="submit" value="스터디 탈퇴">
         </form>
         {% endif %}
-        {% endfor %}
 
-        <!-- 로그인한 유저이고 스터디 멤버가 아닌 경우에만 표시 -->
-        {% if user not in StudyMembers %}
+        {% endfor %}
+        <!-- 현재 유저가 로그인한 유저이고 스터디 멤버가 아닌 경우에만 표시 -->
+        {% if user not in study_members %}
         <form action="{% url 'studies:apply_study_join' study.id %}" method="POST">
             {% csrf_token %}
             <input type="submit" value="가입 신청">
         </form>
         {% endif %}
+        
 
         <a href="{% url 'studies:study_list' %}">목록으로</a>
 


### PR DESCRIPTION
1. 추가한 기능 1.1. 스터디 가입
- 스터디 상세 페이지에서 가입 신청 버튼 클릭 시 StudyMember DB에 `is_accepted`가 `False`인 채로 저장됨.
- 스터디 그룹 리더가 가입 신청 리스트에서 수락할 경우, `is_accepted`가 `True`로 변경됨.
- 가입 신청 리스트에서 거절할 경우, StudyMember DB에서 해당 계정을 삭제함.(가입 신청을 지우는 개념)

1.2. 스터디 멤버 관리
- 스터디 멤버 관리 리스트에서 리더일 경우에는 내보내기 버튼과, 리더 양도 버튼이 표시가 안되도록 템플릿 작성
- 스터디 멤버 관리 리스트에서 내보내기 버튼을 클릭할 경우, StudyMember DB에서 삭제
- 스터디 멤버 관리 리스트에서 리더 위임 버튼을 클릭할 경우, `is_manager`를 `True`로 변경하도록 구현