### PR TITLE
:sparkles: Feat: 회원 탈퇴 기능 개발

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -240,3 +240,15 @@ class AccountUpdateForm(forms.ModelForm):
             raise forms.ValidationError("닉네임에 특수문자를 포함할 수 없습니다.")
 
         return nickname
+
+
+class AccountDeleteForm(forms.ModelForm):
+    password = forms.CharField(
+        required=True,
+        error_messages={"required": "비밀번호를 입력해주세요."},
+        widget=forms.PasswordInput,
+    )
+
+    class Meta:
+        model = User
+        fields = ["password"]

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -10,5 +10,6 @@ urlpatterns = [
     path("login/", views.login, name="login"),
     path("profile/<int:pk>/", views.profile, name="profile"),
     path("edit/", views.account_update, name="account_update"),
+    path("delete/", views.account_delete, name="account_delete"),
     path("", include("allauth.urls")),
 ]

--- a/templates/accounts/account_delete.html
+++ b/templates/accounts/account_delete.html
@@ -1,0 +1,7 @@
+{% block content %}
+<h2>Delete</h2>
+<form method="post" enctype="multipart/form-data">
+    {% csrf_token %} {{ form.as_p }}
+    <button type="submit">Sign up</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
1. 추가한 기능
- 기존에 가입된 계정에 로그인한 사용자가 계정을 삭제할 수 있는 기능

2. 테스트 명령어
- `python manage.py test accounts.tests.TestAccountSecession`

3. 테스트 항목
- 회원 탈퇴 테스트
	- 로그인하지 않은 사용자의 회원 탈퇴 테스트
	- 비밀번호를 입력하지 않은 경우 테스트
	- 비밀번호가 일치하지 않는 경우 테스트
	- 정상 회원 탈퇴 테스트