### PR TITLE
:bug: Fix: Tag 필터링 시 소개글과 제목을 같이 필터링하는 오류 발생

### DIFF
--- a/studies/views.py
+++ b/studies/views.py
@@ -44,14 +44,15 @@ class StudyList(ListView):
     def get_queryset(self):
         queryset = super().get_queryset()
         q = self.request.GET.get("q", "")
+        tq = self.request.GET.get("tq", "")
 
         if q:
             queryset = queryset.filter(
-                Q(title__icontains=q)
-                | Q(introduce__icontains=q)
-                | Q(tags__name__icontains=q)
+                Q(title__icontains=q) | Q(introduce__icontains=q)
             )
 
+        if tq:
+            queryset = queryset.filter(tags__name__in=[tq])
         return queryset
 
     def get_context_data(self, **kwargs):

--- a/templates/studies/study_detail.html
+++ b/templates/studies/study_detail.html
@@ -13,7 +13,7 @@
         <h2>현재 로그인한 사용자 : {{ user }}</h2>
         <h2>{{ study.category }}</h2>
         {% for tag in study.tags.all %}
-        <a href="{% url 'studies:study_list' %}?q={{ tag }}">#{{ tag }} </a>
+        <a href="{% url 'studies:study_list' %}?tq={{ tag }}">#{{ tag }} </a>
         {% endfor %}
         <h2>{{ study.title }}</h2>
         <img src="{{ study.thumbnail.url }}" alt="{{ study.title }}">

--- a/templates/studies/study_list.html
+++ b/templates/studies/study_list.html
@@ -9,7 +9,7 @@
     <body>
         <h1><a href="{% url 'studies:study_list' %}">Study List</a></h1>
         {% for tag in tags %}
-            <a href="{% url 'studies:study_list' %}?q={{ tag }}">#{{ tag }} </a>
+            <a href="{% url 'studies:study_list' %}?tq={{ tag }}">#{{ tag }} </a>
         {% endfor %}
         <ul>
             {% for study in studies %}


### PR DESCRIPTION
1. 원인 1.1. 로직 상 필터링 할 때 소개글과 제목에 `or` 로 필터링을 같이 작성함.

2. 수정 2.1. 별도의 `tag queryset` `tq`를 통해서 필터링 하도록 수정함.
2.2. 그에 따른 템플릿 수정