### PR TITLE
:sparkles: Feat: 스터디 ToDo 생성 기능 (#59)

### DIFF
--- a/studies/models.py
+++ b/studies/models.py
@@ -35,7 +35,7 @@ class Study(models.Model):
         verbose_name_plural = "스터디"
 
     def __str__(self):
-        return f"스터디 명칭 : {self.title}"
+        return self.title
 
 
 class Schedule(models.Model):
@@ -190,7 +190,7 @@ class StudyMember(models.Model):
         verbose_name_plural = "스터디 멤버"
 
     def __str__(self):
-        return f"스터디 : {self.study}"
+        return self.user.nickname
 
 
 class Blacklist(models.Model):

--- a/templates/todos/todo_detail.html
+++ b/templates/todos/todo_detail.html
@@ -22,6 +22,17 @@
       <li>
         스터디 이름 : {{ todo.study.title }}
       </li>
+      <li>
+        투두 메이트 :
+        <ul>
+          {% if not todo.todo_assignees.all %}
+          <li>없음</li>
+          {% endif %}
+          {% for member in todo.todo_assignees.all %}
+          <li>{{ member.assignee.nickname }}</li>
+          {% endfor %}
+        </ul>
+      </li>
       {% endif %}
       <li>투두 이름 : {{ todo.title }}</li>
       <li>상태 : {{ todo.status }}</li>

--- a/templates/todos/todo_list.html
+++ b/templates/todos/todo_list.html
@@ -53,6 +53,16 @@
 
     <section>
       <h3>ToDo</h3>
+      {% if studies %}
+      {% if request.GET.study %}      
+      <a href="{% url 'study_todo_create' pk=request.GET.study %}">추가</a>
+      {% else %}
+      <a href="{% url 'study_todo_create' pk=1 %}">추가</a>
+      {% endif %}
+
+      {% else %}
+      <a href="{% url 'personal_todo_create' %}">추가</a>
+      {% endif %}
       <ul>
         <li>
           <h4>Todo</h4>

--- a/todos/forms.py
+++ b/todos/forms.py
@@ -1,6 +1,10 @@
 from django import forms
 
+from django.contrib.auth import get_user_model
+from studies.models import Study, StudyMember
 from todos.models import ToDo
+
+User = get_user_model()
 
 
 class PersonalToDoForm(forms.ModelForm):
@@ -46,3 +50,54 @@ class PersonalToDoForm(forms.ModelForm):
             self.add_error("end_at", "종료일은 시작일보다 이후이어야 합니다.")
 
         return cleaned_data
+
+
+class StudyToDoForm(forms.ModelForm):
+    assignees = forms.ModelMultipleChoiceField(
+        queryset=StudyMember.objects.none(),
+        widget=forms.CheckboxSelectMultiple,
+        required=False,
+    )
+    start_at = forms.SplitDateTimeField(
+        widget=forms.SplitDateTimeWidget(
+            date_attrs={"type": "date"}, time_attrs={"type": "time"}
+        ),
+        required=False,
+    )
+    end_at = forms.SplitDateTimeField(
+        widget=forms.SplitDateTimeWidget(
+            date_attrs={"type": "date"}, time_attrs={"type": "time"}
+        ),
+        required=False,
+    )
+
+    class Meta:
+        model = ToDo
+        fields = (
+            "status",
+            "title",
+            "content",
+            "start_at",
+            "end_at",
+            "alert_set",
+        )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        start_at = cleaned_data.get("start_at")
+        end_at = cleaned_data.get("end_at")
+
+        if bool(start_at) != bool(end_at):
+            self.add_error("start_at", "시작일과 종료일 둘 다 입력되어야 합니다.")
+            self.add_error("end_at", "시작일과 종료일 둘 다 입력되어야 합니다.")
+
+        if (start_at and end_at) and (start_at > end_at):
+            self.add_error("start_at", "시작일은 종료일보다 이전이어야 합니다.")
+            self.add_error("end_at", "종료일은 시작일보다 이후이어야 합니다.")
+
+        return cleaned_data
+
+    def __init__(self, *args, **kwargs):
+        study_id = kwargs.pop("pk", None)
+        super().__init__(*args, **kwargs)
+        self.fields["assignees"].queryset = StudyMember.objects.filter(study=study_id)

--- a/todos/tests/test_forms.py
+++ b/todos/tests/test_forms.py
@@ -1,9 +1,13 @@
 import datetime
 
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.utils import timezone
 
-from todos.forms import PersonalToDoForm
+from studies.models import Study, Category, StudyMember
+from todos.forms import PersonalToDoForm, StudyToDoForm
+
+User = get_user_model()
 
 
 class PersonalToDoFormTest(TestCase):
@@ -41,6 +45,87 @@ class PersonalToDoFormTest(TestCase):
         self.assertFalse(form.is_valid())
 
     # start_at필드가 end_at필드보다 이전 날짜인 경우, 거부하는지 테스트
+    def test_start_at_is_before_end_at(self):
+        date = datetime.datetime.now()
+        form = PersonalToDoForm(
+            data={
+                "title": "test",
+                "content": "test",
+                "start_at_0": (date + timezone.timedelta(days=1)).date().isoformat(),
+                "start_at_1": (date + timezone.timedelta(days=1)).time().isoformat(),
+                "end_at_0": date.date().isoformat(),
+                "end_at_1": date.time().isoformat(),
+                "status": "ToDo",
+                "alert_set": "없음",
+            }
+        )
+
+        self.assertFalse(form.is_valid())
+
+
+class StudyToDoFormTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        number_of_users = 3
+        for user_id in range(1, number_of_users + 1):
+            User.objects.create_user(
+                nickname=f"testuser{user_id}",
+                email=f"testuser{user_id}@example.com",
+                password=f"{user_id}HJ1vRV0Z&2iD",
+            )
+
+        cls.study = Study.objects.create(
+            title="TestStudy",
+            category=Category.objects.create(name="TestCategory"),
+            goal="Test Goal",
+            start_at=timezone.now().date(),
+            end_at=timezone.now().date() + timezone.timedelta(days=7),
+            difficulty="상",
+            max_member=5,
+        )
+
+        for user in User.objects.all():
+            StudyMember.objects.create(user=user, study=cls.study)
+
+        cls.study_member1 = StudyMember.objects.get(id=1)
+        cls.study_member2 = StudyMember.objects.get(id=2)
+        cls.study_member3 = StudyMember.objects.get(id=3)
+
+    def test_assignee_multiple_study_member_selected(self):
+        """
+        assignees필드에 유저가 여러명 선택되었을 경우 유효한지 테스트
+        """
+        form = StudyToDoForm(
+            data={
+                "title": "test",
+                "assignees": [
+                    self.study_member1,
+                    self.study_member2,
+                    self.study_member3,
+                ],
+                "status": "ToDo",
+                "alert_set": "없음",
+            },
+            pk=self.study.id,
+        )
+        print(form.errors)
+        self.assertTrue(form.is_valid())
+
+    def test_both_start_at_and_end_at_should_be_filled(self):
+        date = datetime.datetime.now()
+        form = PersonalToDoForm(
+            data={
+                "title": "test",
+                "content": "test",
+                "start_at_0": date.date().isoformat(),
+                "start_at_1": date.time().isoformat(),
+                "status": "ToDo",
+                "alert_set": "없음",
+            }
+        )
+        
+        self.assertFalse(form.is_valid())
+
     def test_start_at_is_before_end_at(self):
         date = datetime.datetime.now()
         form = PersonalToDoForm(

--- a/todos/tests/test_views.py
+++ b/todos/tests/test_views.py
@@ -695,6 +695,15 @@ class StudyToDoCreateTest(TestCase):
 
         self.assertTemplateUsed(response, "todos/todo_form.html")
 
+    def test_logged_in_with_my_study_members(self):
+        """
+        해당 스터디의 멤버가 아닌 경우, study_detail로 리다이렉트 되는지 확인
+        """
+        login = self.client.login(email="testuser5@example.com", password="5HJ1vRV0Z&2iD")
+        response = self.client.get(reverse("study_todo_create", kwargs={"pk": 1}))
+
+        self.assertRedirects(response, "/study/1/")
+
     def test_create_todo(self):
         """
         할 일 생성 성공

--- a/todos/urls.py
+++ b/todos/urls.py
@@ -12,6 +12,11 @@ urlpatterns = [
         name="personal_todo_create",
     ),
     path(
+        "study/<int:pk>/create/",
+        views.StudyToDoCreate.as_view(),
+        name="study_todo_create",
+    ),
+    path(
         "personal/edit/<int:pk>/",
         views.PersonalToDoUpdate.as_view(),
         name="personal_todo_edit",


### PR DESCRIPTION
1. 추가한 기능
     - `todos/study/<int:pk>/create` url 생성
     - 로그인 권한, 접근 권한 설정
     - 할당자 선택시 해당 스터디 멤버만 가능(체크박스)
     - todo_list, todo_detail 템플릿 수정

2. 기능 설명
    2.1 테스트 코드 작성
      - 스터디 ToDo 생성 폼
      - 스터디 ToDo 생성 성공, 생성 성공 후 스터디 ToDo 리스트로 리다이렉트
      - 해당 스터디의 멤버가 아닌 경우, 스터디 상세로 리다이렉트

    2.2 로그인 권한, 접근 권한 설정
   - UserPassesTestMixin으로 해당 스터디의 멤버인지 확인
   - 로그인 권한, 접근 권한에 따른 redirect 위치 지정
      - 로그인 권한 -> 로그인 페이지
      - 접근 권한 -> 스터디 상세 페이지

   2.3 todo_list, todo_detail 템플릿 수정
   - 템플릿 todo_list에 추가 버튼 추가
   - 템플릿 todo_detail에 투두 메이트 추가

3. 비고
     - asignees는 여러명 할당가능, 선택값으로 설정
     - study는 self.kwargs.get("pk")을 통해 할당
     - studies앱에서 Study, StudyMember 모델의 __str__ 메소드 수정