### PR TITLE
:sparkles: Feat: 스터디 할 일 수정 (#74)

### DIFF
--- a/templates/todos/todo_detail.html
+++ b/templates/todos/todo_detail.html
@@ -13,6 +13,7 @@
 
     <a href="{% url 'todo_list' %}">목록</a>
     {% if todo.study %}
+    <a href="{% url 'study_todo_edit' study_id=todo.study.id pk=todo.id %}">수정</a>
     {% else %}
     <a href="{% url 'personal_todo_edit' todo.pk %}">수정</a>
     {% endif %}

--- a/templates/todos/todo_list.html
+++ b/templates/todos/todo_list.html
@@ -55,9 +55,9 @@
       <h3>ToDo</h3>
       {% if studies %}
       {% if request.GET.study %}      
-      <a href="{% url 'study_todo_create' pk=request.GET.study %}">추가</a>
+      <a href="{% url 'study_todo_create' study_id=request.GET.study %}">추가</a>
       {% else %}
-      <a href="{% url 'study_todo_create' pk=1 %}">추가</a>
+      <a href="{% url 'study_todo_create' study_id=1 %}">추가</a>
       {% endif %}
 
       {% else %}

--- a/todos/forms.py
+++ b/todos/forms.py
@@ -80,6 +80,7 @@ class StudyToDoForm(forms.ModelForm):
             "start_at",
             "end_at",
             "alert_set",
+            "assignees",
         )
 
     def clean(self):
@@ -98,6 +99,6 @@ class StudyToDoForm(forms.ModelForm):
         return cleaned_data
 
     def __init__(self, *args, **kwargs):
-        study_id = kwargs.pop("pk", None)
+        study_id = kwargs.pop("study_id", None)
         super().__init__(*args, **kwargs)
         self.fields["assignees"].queryset = StudyMember.objects.filter(study=study_id)

--- a/todos/tests/test_forms.py
+++ b/todos/tests/test_forms.py
@@ -106,7 +106,7 @@ class StudyToDoFormTest(TestCase):
                 "status": "ToDo",
                 "alert_set": "없음",
             },
-            pk=self.study.id,
+            study_id=self.study.id,
         )
         print(form.errors)
         self.assertTrue(form.is_valid())
@@ -123,7 +123,7 @@ class StudyToDoFormTest(TestCase):
                 "alert_set": "없음",
             }
         )
-        
+
         self.assertFalse(form.is_valid())
 
     def test_start_at_is_before_end_at(self):
@@ -142,3 +142,13 @@ class StudyToDoFormTest(TestCase):
         )
 
         self.assertFalse(form.is_valid())
+
+    def test_assignees_field_should_be_loaded(self):
+        """
+        assignees필드 데이터가 불러와지는지 테스트
+        """
+        form = StudyToDoForm(study_id=self.study.id)
+        self.assertEqual(
+            list(form.fields["assignees"].queryset),
+            list(StudyMember.objects.filter(study=self.study)),
+        )

--- a/todos/tests/test_views.py
+++ b/todos/tests/test_views.py
@@ -681,7 +681,7 @@ class StudyToDoCreateTest(TestCase):
         """
         로그인 안 했을 때 로그인 페이지로 리다이렉트 되는지 확인
         """
-        response = self.client.get(reverse("study_todo_create", kwargs={"pk": 1}))
+        response = self.client.get(reverse("study_todo_create", kwargs={"study_id": 1}))
         self.assertRedirects(response, "/accounts/login/?next=/todos/study/1/create/")
 
     def test_logged_in_uses_correct_template(self):
@@ -691,7 +691,7 @@ class StudyToDoCreateTest(TestCase):
         login = self.client.login(
             email="testuser1@example.com", password="1HJ1vRV0Z&2iD"
         )
-        response = self.client.get(reverse("study_todo_create", kwargs={"pk": 1}))
+        response = self.client.get(reverse("study_todo_create", kwargs={"study_id": 1}))
 
         self.assertTemplateUsed(response, "todos/todo_form.html")
 
@@ -699,8 +699,10 @@ class StudyToDoCreateTest(TestCase):
         """
         해당 스터디의 멤버가 아닌 경우, study_detail로 리다이렉트 되는지 확인
         """
-        login = self.client.login(email="testuser5@example.com", password="5HJ1vRV0Z&2iD")
-        response = self.client.get(reverse("study_todo_create", kwargs={"pk": 1}))
+        login = self.client.login(
+            email="testuser5@example.com", password="5HJ1vRV0Z&2iD"
+        )
+        response = self.client.get(reverse("study_todo_create", kwargs={"study_id": 1}))
 
         self.assertRedirects(response, "/study/1/")
 
@@ -713,7 +715,7 @@ class StudyToDoCreateTest(TestCase):
         )
 
         response = self.client.post(
-            reverse("study_todo_create", kwargs={"pk": 1}),
+            reverse("study_todo_create", kwargs={"study_id": 1}),
             {
                 "title": "test",
                 "content": "test",
@@ -737,7 +739,7 @@ class StudyToDoCreateTest(TestCase):
         )
 
         response = self.client.post(
-            reverse("study_todo_create", kwargs={"pk": 1}),
+            reverse("study_todo_create", kwargs={"study_id": 1}),
             {
                 "title": "test",
                 "status": "ToDo",

--- a/todos/urls.py
+++ b/todos/urls.py
@@ -12,7 +12,7 @@ urlpatterns = [
         name="personal_todo_create",
     ),
     path(
-        "study/<int:pk>/create/",
+        "study/<int:study_id>/create/",
         views.StudyToDoCreate.as_view(),
         name="study_todo_create",
     ),

--- a/todos/urls.py
+++ b/todos/urls.py
@@ -21,5 +21,10 @@ urlpatterns = [
         views.PersonalToDoUpdate.as_view(),
         name="personal_todo_edit",
     ),
+    path(
+        "study/<int:study_id>/edit/<int:pk>/",
+        views.StudyToDoUpdate.as_view(),
+        name="study_todo_edit",
+    ),
     path("delete/<int:pk>/", views.ToDoDelete.as_view(), name="todo_delete"),
 ]

--- a/todos/views.py
+++ b/todos/views.py
@@ -225,9 +225,7 @@ class StudyToDoUpdate(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
     def get_initial(self):
         initial = super().get_initial()
         assignees = list(
-            self.object.todo_assignees.filter(todo=self.object).values_list(
-                "assignee__id", flat=True
-            )
+            self.object.todo_assignees.values_list("assignee__id", flat=True)
         )
         initial["assignees"] = assignees
         return initial


### PR DESCRIPTION
1. 추가한 기능
     - 테스트 코드 작성
     - `todos/study/<int:study_id>/edit/<int:pk>/` url 생성
     - 로그인 권한, 접근 권한 설정
     - 기존 데이터를 불러와 form 초기 설정
     - todo_detail 템플릿에 스터디 ToDo 수정 버튼 추가

2. 기능 설명
     2.1 테스트 코드 작성
     - 스터디 할 일 수정 성공
     - 스터디가 아닌 멤버에 대한 접근 제한
     - 수정시 assignees에 대한 초기 설정에 대한 테스트 작성

     2.2 로그인 권한, 접근 권한 설정
     - LoginRequiredMixin 상속으로 로그인 필수 설정
     - UserPassesTestMixin 상속으로 해당 스터디의 멤버인지 확인

     2.3 기존 데이터를 불러와 form 초기 설정
     - get_initial 함수을 사용하여 기존 데이터를 보여줌
     - assignees를 수정할 때, 기존 데이터는 삭제한 후 다시 재할당

3. 비고
스터디 생성 URL 패턴 재구성

    3.1 수정 이유
     - 생성과 수정에 대한 기본 키 (pk) 처리의 일관성 부재
     - 생성 및 수정 작업 간에 pk에 대해 혼동할 가능성 존재
     - 변경은 URL에서 스터디 식별자를 더 일관되고 명확하게 나타내도록 보장

    3.2 수정
     - "study/<int:pk>/create/" URL 패턴을 "study/<int:study_id>/create/"으로 변경
     - pk로 작성된 코드를 study_id로 모두 변경
     - 폼에서 assignees필드 데이터가 불러와지는지 테스트 추가
