### PR TITLE
:bug: Fix: 채팅방 입장 시 인증 불가 문제 해결 ( #81 )

### DIFF
--- a/chats/admin.py
+++ b/chats/admin.py
@@ -1,3 +1,6 @@
 from django.contrib import admin
+from .models import DirectChat, StudyChat, ChatMessage
 
-# Register your models here.
+admin.site.register(DirectChat)
+admin.site.register(StudyChat)
+admin.site.register(ChatMessage)

--- a/deVtail/settings.py
+++ b/deVtail/settings.py
@@ -152,7 +152,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.2/howto/static-files/
 
-STATIC_URL = "/static/"
+STATIC_URL = "static/"
 STATICFILES_DIRS = [
     BASE_DIR / "static",
 ]
@@ -191,3 +191,10 @@ ACCOUNT_ADAPTER = "accounts.adapters.CustomAccountAdapter"
 LOGIN_REDIRECT_URL = "/"
 
 os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
+
+# Django Channels 설정
+CHANNEL_LAYERS = {
+    "default": {
+        "BACKEND": "channels.layers.InMemoryChannelLayer",
+    },
+}

--- a/templates/chats/temp_direct_chat.html
+++ b/templates/chats/temp_direct_chat.html
@@ -25,6 +25,12 @@
 
     socket.addEventListener('open', (event) => {
       console.log('WebSocket 연결 성공:', event);
+      const type = "auth";
+      const user = '{{ user }}';
+      const user_id = '{{ user.id }}';
+      const data = { type, user, user_id };
+      socket.send(JSON.stringify(data));
+      console.log('Auth 메시지 전송:', data);
     });
 
     socket.addEventListener('message', (event) => {
@@ -45,9 +51,12 @@
     function sendMessage() {
       const message = messageInput.value;
       if (message.trim() !== '') {
-        const sender = 'Me';
-        const data = { message, sender };
+        const type = "chat_message";
+        const user = '{{ user }}';
+        const user_id = '{{ user.id }}';
+        const data = { type, message, user, user_id };
         socket.send(JSON.stringify(data));
+        console.log('메시지 전송:', data);
         messageInput.value = '';
       }
     }

--- a/templates/devmates/devmate_list.html
+++ b/templates/devmates/devmate_list.html
@@ -15,10 +15,11 @@
     {% for devmate in devmates %}
       <p>{{ devmate.sent_user }}</p>
       <p>{{ devmate.received_user }}</p>
-      <!-- 버튼 생성 -->
+      <!-- 채팅방 입장 버튼 -->
       <form action="{% url 'chats:create_or_connect_direct_chat' %}" method="get">
         {% csrf_token %}
   <input type="hidden" name="target_user_id" value="{% if request.user.id == devmate.sent_user.id %}{{ devmate.received_user.id }}{% else %}{{ devmate.sent_user.id }}{% endif %}">
+  <input type="hidden" name="request_user_id" value="{{ request.user.id }}">
   <button type="submit">Start Direct Chat</button>
       </form>
       <!-- 삭제하기 버튼 -->


### PR DESCRIPTION
## 수정한 내용
채팅방 입장 시 self.scope의 정보에 user가 없어 요청한 유저 정보를 확인할 수 없던 문제 해결
 - connect 시 scope의 header에 포함된 sessionid를 통해 유저 정보 추출

## 비고
코드가 더럽습니다.. 완성된 후 정리, 주석 작성 하겠습니다.

현재 OnlineUserManager를 통해 채팅방의 유저를 등록,
인증 시 등록된 유저인지 확인하는 형태로 구현되고 있습니다.
접속한 유저정보를 받아 이 정보와 대조하는 것,
메시지를 받아와서 전송하는 것 두가지만 완성되면 1:1 채팅 구현이 완료될 것 같습니다.
현재 뼈대는 만들어져있으나 message 형태 문제로 오류가 나는 것을 확인, 수정중입니다.