### PR TITLE
🐛 Fix: 화면 전환 시 테마 모드가 유지되지 않는 현상 해결

### DIFF
--- a/static/assets/js/base.js
+++ b/static/assets/js/base.js
@@ -1,5 +1,16 @@
 const dropdowns = document.getElementsByClassName("dropdown");
 var i;
+const $html = document.querySelector('html');
+const theme = localStorage.getItem('theme');
+const $theme_btn = document.querySelector('.theme_btn');
+
+if (theme === 'dark') {
+    $html.setAttribute('data-theme', 'dark');
+    $theme_btn.setAttribute('value', 'light');
+} else {
+    $html.setAttribute('data-theme', 'light');
+    $theme_btn.setAttribute('value', 'dark');
+}
 
 for (i = 0; i < dropdowns.length; i++) {
     dropdowns[i].addEventListener('click', function () {
@@ -12,8 +23,12 @@ for (i = 0; i < dropdowns.length; i++) {
     });
 }
 
-// 뒤로가기 버튼
-document.getElementById("backBtn").addEventListener("click", (event) => {
-    event.preventDefault();
-    history.back();
+
+$theme_btn.addEventListener('click', () => {
+    const current_theme = localStorage.getItem('theme');
+    if (current_theme === 'dark') {
+        localStorage.setItem('theme', 'light');
+    } else {
+        localStorage.setItem('theme', 'dark');
+    }
 });

--- a/static/assets/js/base.js
+++ b/static/assets/js/base.js
@@ -32,3 +32,9 @@ $theme_btn.addEventListener('click', () => {
         localStorage.setItem('theme', 'dark');
     }
 });
+
+// 뒤로가기 버튼
+document.getElementById("backBtn").addEventListener("click", (event) => {
+    event.preventDefault();
+    history.back();
+});

--- a/static/assets/js/main.js
+++ b/static/assets/js/main.js
@@ -1,14 +1,13 @@
 const $holiday_p1 = document.querySelector('.holiday_p_1');
 const $holiday_p2 = document.querySelector('.holiday_p_2');
 const $holiday_p3 = document.querySelector('.holiday_p_3');
-// 목표 날짜 설정
-// const countDownDate = new Date("Mar 31, 2024 23:59:59").getTime();
+
 const year = $holiday_p1.dataset.holiday.split(' ')[0].replace('년', '');
 const month = $holiday_p1.dataset.holiday.split(' ')[1].replace('월', '');
 const day = $holiday_p1.dataset.holiday.split(' ')[2].replace('일', '');
 const countDownDate = new Date(year, month, day).getTime();
 let interval;
-// 1초마다 업데이트되는 함수
+
 function countdownFunction(dest_date) {
     const updateCountdown = () => {
         const now = new Date().getTime();
@@ -18,7 +17,6 @@ function countdownFunction(dest_date) {
         const minutes = Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60));
         const seconds = Math.floor((distance % (1000 * 60)) / 1000);
 
-        // Update the DOM elements with the countdown values
         const $day_span = document.querySelector('.day');
         $day_span.style.setProperty('--value', days);
 
@@ -31,7 +29,7 @@ function countdownFunction(dest_date) {
         const $sec_span = document.querySelector('.sec');
         $sec_span.style.setProperty('--value', seconds);
     };
-    // Call the updateCountdown function every second
+
     clearInterval(interval);
     interval = setInterval(updateCountdown, 1000);
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,6 +1,6 @@
 {% load static %}
 <!DOCTYPE html>
-<html lang="ko" data-theme="winter">
+<html lang="ko" data-theme="light">
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -25,20 +25,9 @@
                             <button type="button" class="relative inline-flex items-center justify-center rounded-md p-2 text-gray-400 hover:bg-gray-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white" aria-controls="mobile-menu" aria-expanded="false">
                                 <span class="absolute -inset-0.5"></span>
                                 <span class="sr-only">Open main menu</span>
-                                <!--
-                                    Icon when menu is closed.
-                    
-                                    Menu open: "hidden", Menu closed: "block"
-                                -->
-                                
                                 <svg class="block h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
                                 </svg>
-                                <!--
-                                    Icon when menu is open.
-                    
-                                    Menu open: "block", Menu closed: "hidden"
-                                -->
                                 <svg class="hidden h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
                                 </svg>
@@ -50,8 +39,6 @@
                             </div>
                             <div class="hidden sm:ml-6 sm:block">
                                 <div class="flex space-x-4">
-                                    <!-- Current: "bg-gray-900 text-white", Default: "text-gray-300 hover:bg-gray-700 hover:text-white" -->
-                                    <!-- <a href="#" class="bg-gray-900 text-white rounded-md px-3 py-2 text-sm font-medium" aria-current="page">Home</a> -->
                                     <details class="dropdown">
                                         <summary class="m-1 btn border-0 bg-transparent shadow-none">스터디</summary>
                                         <ul class="p-2 menu dropdown-content z-[1] rounded-box w-52 border-none" style="z-index: 100;">
@@ -141,14 +128,11 @@
                     </svg>
                 </a>
                 <label class="swap swap-rotate">
-                    <!-- this hidden checkbox controls the state -->
-                    <input type="checkbox" class="theme-controller" value="night" />
-                    <!-- sun icon -->
+                    <input type="checkbox" class="theme-controller theme_btn" value="dark" />
                     <svg class="swap-on fill-current w-10 h-10" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                         <path
                             d="M5.64,17l-.71.71a1,1,0,0,0,0,1.41,1,1,0,0,0,1.41,0l.71-.71A1,1,0,0,0,5.64,17ZM5,12a1,1,0,0,0-1-1H3a1,1,0,0,0,0,2H4A1,1,0,0,0,5,12Zm7-7a1,1,0,0,0,1-1V3a1,1,0,0,0-2,0V4A1,1,0,0,0,12,5ZM5.64,7.05a1,1,0,0,0,.7.29,1,1,0,0,0,.71-.29,1,1,0,0,0,0-1.41l-.71-.71A1,1,0,0,0,4.93,6.34Zm12,.29a1,1,0,0,0,.7-.29l.71-.71a1,1,0,1,0-1.41-1.41L17,5.64a1,1,0,0,0,0,1.41A1,1,0,0,0,17.66,7.34ZM21,11H20a1,1,0,0,0,0,2h1a1,1,0,0,0,0-2Zm-9,8a1,1,0,0,0-1,1v1a1,1,0,0,0,2,0V20A1,1,0,0,0,12,19ZM18.36,17A1,1,0,0,0,17,18.36l.71.71a1,1,0,0,0,1.41,0,1,1,0,0,0,0-1.41ZM12,6.5A5.5,5.5,0,1,0,17.5,12,5.51,5.51,0,0,0,12,6.5Zm0,9A3.5,3.5,0,1,1,15.5,12,3.5,3.5,0,0,1,12,15.5Z" />
                     </svg>
-                    <!-- moon icon -->
                     <svg class="swap-off fill-current w-10 h-10" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                         <path
                             d="M21.64,13a1,1,0,0,0-1.05-.14,8.05,8.05,0,0,1-3.37.73A8.15,8.15,0,0,1,9.08,5.49a8.59,8.59,0,0,1,.25-2A1,1,0,0,0,8,2.36,10.14,10.14,0,1,0,22,14.05,1,1,0,0,0,21.64,13Zm-9.5,6.69A8.14,8.14,0,0,1,7.08,5.22v.27A10.15,10.15,0,0,0,17.22,15.63a9.79,9.79,0,0,0,2.1-.22A8.11,8.11,0,0,1,12.14,19.73Z" />


### PR DESCRIPTION
1. 원인
- base.html에 html 태그에 지정된 속성 값이 모든 페이지가 렌더링될 때마다 적용되면서 다크 모드로 변경한 뒤 다른 페이지가 렌더링될 경우 다시 라이트 모드로 렌더링되는 현상

2. 수정
- 해당 속성 값을 로컬 스토리지에 저장해두었다가 저장된 로컬 스토리지 값이 있는 경우 페이지가 렌더링될 때 해당 테마 속성 값으로 지정할 수 있도록 변경