### PR TITLE
:bug: Fix: todo 프로필 이미지 깨짐 현상 수정

### DIFF
--- a/templates/todos/todo_list.html
+++ b/templates/todos/todo_list.html
@@ -31,15 +31,17 @@
           <a href="?study={{ params.study }}&user=all">
           <div class="avatar">
             <div class="w-20 rounded-full shadow-md {% if params.user == 'all' %}ring ring-primary ring-offset-base-100 ring-offset-2{% endif %}">
-              {% if member.user.profile_image %}
-                <img src="{{ member.user.profile_image }}" alt="프로필 이미지" />
-              {% else %}
+              {% if not member.user.profile_image %}
                 <div class="h-full flex justify-center items-center bg-base-100">
                   <svg xmlns="http://www.w3.org/2000/svg" class="fill-current w-2/3 h-2/3" viewBox="0 0 448 512">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                       d="M304 128a80 80 0 1 0 -160 0 80 80 0 1 0 160 0zM96 128a128 128 0 1 1 256 0A128 128 0 1 1 96 128zM49.3 464H398.7c-8.9-63.3-63.3-112-129-112H178.3c-65.7 0-120.1 48.7-129 112zM0 482.3C0 383.8 79.8 304 178.3 304h91.4C368.2 304 448 383.8 448 482.3c0 16.4-13.3 29.7-29.7 29.7H29.7C13.3 512 0 498.7 0 482.3z" />
                   </svg>
                 </div>
+              {% elif 'http' in user.profile_image.url %}
+              <img src="{{ member.user.profile_image }}" alt="프로필 이미지" />
+              {% else %}
+              <img src="{{ member.user.profile_image.url }}" alt="프로필 이미지" />
               {% endif %}
             </div>
           </div>
@@ -51,15 +53,17 @@
           <a href="?user=all">
             <div class="avatar">
               <div class="w-20 rounded-full shadow-md {% if params.user == 'all' %}ring ring-primary ring-offset-base-100 ring-offset-2{% endif %}">
-                {% if member.user.profile_image %}
-                  <img src="{{ member.user.profile_image }}" alt="프로필 이미지" />
+                {% if not member.user.profile_image %}
+                <div class="h-full flex justify-center items-center bg-base-100">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="fill-current w-2/3 h-2/3" viewBox="0 0 448 512">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                      d="M304 128a80 80 0 1 0 -160 0 80 80 0 1 0 160 0zM96 128a128 128 0 1 1 256 0A128 128 0 1 1 96 128zM49.3 464H398.7c-8.9-63.3-63.3-112-129-112H178.3c-65.7 0-120.1 48.7-129 112zM0 482.3C0 383.8 79.8 304 178.3 304h91.4C368.2 304 448 383.8 448 482.3c0 16.4-13.3 29.7-29.7 29.7H29.7C13.3 512 0 498.7 0 482.3z" />
+                  </svg>
+                </div>
+                {% elif 'http' in user.profile_image.url %}
+                <img src="{{ member.user.profile_image }}" alt="프로필 이미지" />
                 {% else %}
-                  <div class="h-full flex justify-center items-center bg-base-100">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="fill-current w-2/3 h-2/3" viewBox="0 0 448 512">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                        d="M304 128a80 80 0 1 0 -160 0 80 80 0 1 0 160 0zM96 128a128 128 0 1 1 256 0A128 128 0 1 1 96 128zM49.3 464H398.7c-8.9-63.3-63.3-112-129-112H178.3c-65.7 0-120.1 48.7-129 112zM0 482.3C0 383.8 79.8 304 178.3 304h91.4C368.2 304 448 383.8 448 482.3c0 16.4-13.3 29.7-29.7 29.7H29.7C13.3 512 0 498.7 0 482.3z" />
-                    </svg>
-                  </div>
+                <img src="{{ member.user.profile_image.url }}" alt="프로필 이미지" />
                 {% endif %}
               </div>
             </div>
@@ -73,15 +77,17 @@
           <a href="?study={{ params.study }}&user={{ member.user.id }}">
           <div class="avatar">
             <div class="w-20 rounded-full shadow-md {% if params.user == member.user.id|stringformat:'s' %}ring ring-primary ring-offset-base-100 ring-offset-2{% endif %}">
-              {% if member.user.profile_image %}
-                <img src="{{ member.user.profile_image }}" alt="프로필 이미지" />
+              {% if not member.user.profile_image %}
+              <div class="h-full flex justify-center items-center bg-base-100">
+                <svg xmlns="http://www.w3.org/2000/svg" class="fill-current w-2/3 h-2/3" viewBox="0 0 448 512">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                    d="M304 128a80 80 0 1 0 -160 0 80 80 0 1 0 160 0zM96 128a128 128 0 1 1 256 0A128 128 0 1 1 96 128zM49.3 464H398.7c-8.9-63.3-63.3-112-129-112H178.3c-65.7 0-120.1 48.7-129 112zM0 482.3C0 383.8 79.8 304 178.3 304h91.4C368.2 304 448 383.8 448 482.3c0 16.4-13.3 29.7-29.7 29.7H29.7C13.3 512 0 498.7 0 482.3z" />
+                </svg>
+              </div>
+              {% elif 'http' in user.profile_image.url %}
+              <img src="{{ member.user.profile_image }}" alt="프로필 이미지" />
               {% else %}
-                <div class="h-full flex justify-center items-center bg-base-100">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="fill-current w-2/3 h-2/3" viewBox="0 0 448 512">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                      d="M304 128a80 80 0 1 0 -160 0 80 80 0 1 0 160 0zM96 128a128 128 0 1 1 256 0A128 128 0 1 1 96 128zM49.3 464H398.7c-8.9-63.3-63.3-112-129-112H178.3c-65.7 0-120.1 48.7-129 112zM0 482.3C0 383.8 79.8 304 178.3 304h91.4C368.2 304 448 383.8 448 482.3c0 16.4-13.3 29.7-29.7 29.7H29.7C13.3 512 0 498.7 0 482.3z" />
-                  </svg>
-                </div>
+              <img src="{{ member.user.profile_image.url }}" alt="프로필 이미지" />
               {% endif %}
             </div>
           </div>
@@ -93,16 +99,18 @@
           <a href="?user={{ member.user.id }}">
             <div class="avatar">
               <div class="w-20 rounded-full shadow-md {% if params.user == member.user.id|stringformat:'s' %}ring ring-primary ring-offset-base-100 ring-offset-2{% endif %}">
-              {% if member.user.profile_image %}
-                <img src="{{ member.user.profile_image }}" alt="프로필 이미지" />
-              {% else %}
+                {% if not member.user.profile_image %}
                 <div class="h-full flex justify-center items-center bg-base-100">
                   <svg xmlns="http://www.w3.org/2000/svg" class="fill-current w-2/3 h-2/3" viewBox="0 0 448 512">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                       d="M304 128a80 80 0 1 0 -160 0 80 80 0 1 0 160 0zM96 128a128 128 0 1 1 256 0A128 128 0 1 1 96 128zM49.3 464H398.7c-8.9-63.3-63.3-112-129-112H178.3c-65.7 0-120.1 48.7-129 112zM0 482.3C0 383.8 79.8 304 178.3 304h91.4C368.2 304 448 383.8 448 482.3c0 16.4-13.3 29.7-29.7 29.7H29.7C13.3 512 0 498.7 0 482.3z" />
                   </svg>
                 </div>
-              {% endif %}
+                {% elif 'http' in user.profile_image.url %}
+                <img src="{{ member.user.profile_image }}" alt="프로필 이미지" />
+                {% else %}
+                <img src="{{ member.user.profile_image.url }}" alt="프로필 이미지" />
+                {% endif %}
               </div>
             </div>
             <p>{{ member.user.nickname }}</p>
@@ -154,15 +162,17 @@
                     {% if forloop.counter <= 2 %}
                     <div class="avatar shadow-md">
                       <div class="w-8">
-                        {% if member.user.profile_image %}
-                        <img src="{{ member.user.profile_image }}" alt="프로필 이미지" />
-                        {% else %}
+                        {% if not assignee.assignee.profile_image %}
                         <div class="h-full flex justify-center items-center bg-base-100">
                           <svg xmlns="http://www.w3.org/2000/svg" class="fill-current w-2/3 h-2/3" viewBox="0 0 448 512">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                               d="M304 128a80 80 0 1 0 -160 0 80 80 0 1 0 160 0zM96 128a128 128 0 1 1 256 0A128 128 0 1 1 96 128zM49.3 464H398.7c-8.9-63.3-63.3-112-129-112H178.3c-65.7 0-120.1 48.7-129 112zM0 482.3C0 383.8 79.8 304 178.3 304h91.4C368.2 304 448 383.8 448 482.3c0 16.4-13.3 29.7-29.7 29.7H29.7C13.3 512 0 498.7 0 482.3z" />
                           </svg>
                         </div>
+                        {% elif 'http' in user.profile_image.url %}
+                        <img src="{{ assignee.assignee.profile_image }}" alt="프로필 이미지" />
+                        {% else %}
+                        <img src="{{ assignee.assignee.profile_image.url }}" alt="프로필 이미지" />
                         {% endif %}
                       </div>
                   </div>
@@ -244,15 +254,17 @@
                     {% if forloop.counter <= 2 %}
                     <div class="avatar shadow-md">
                       <div class="w-8">
-                        {% if member.user.profile_image %}
-                          <img src="{{ member.user.profile_image }}" alt="프로필 이미지" />
+                        {% if not assignee.assignee.profile_image %}
+                        <div class="h-full flex justify-center items-center bg-base-100">
+                          <svg xmlns="http://www.w3.org/2000/svg" class="fill-current w-2/3 h-2/3" viewBox="0 0 448 512">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                              d="M304 128a80 80 0 1 0 -160 0 80 80 0 1 0 160 0zM96 128a128 128 0 1 1 256 0A128 128 0 1 1 96 128zM49.3 464H398.7c-8.9-63.3-63.3-112-129-112H178.3c-65.7 0-120.1 48.7-129 112zM0 482.3C0 383.8 79.8 304 178.3 304h91.4C368.2 304 448 383.8 448 482.3c0 16.4-13.3 29.7-29.7 29.7H29.7C13.3 512 0 498.7 0 482.3z" />
+                          </svg>
+                        </div>
+                        {% elif 'http' in user.profile_image.url %}
+                        <img src="{{ assignee.assignee.profile_image }}" alt="프로필 이미지" />
                         {% else %}
-                          <div class="h-full flex justify-center items-center bg-base-100">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="fill-current w-2/3 h-2/3" viewBox="0 0 448 512">
-                              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                d="M304 128a80 80 0 1 0 -160 0 80 80 0 1 0 160 0zM96 128a128 128 0 1 1 256 0A128 128 0 1 1 96 128zM49.3 464H398.7c-8.9-63.3-63.3-112-129-112H178.3c-65.7 0-120.1 48.7-129 112zM0 482.3C0 383.8 79.8 304 178.3 304h91.4C368.2 304 448 383.8 448 482.3c0 16.4-13.3 29.7-29.7 29.7H29.7C13.3 512 0 498.7 0 482.3z" />
-                            </svg>
-                          </div>
+                        <img src="{{ assignee.assignee.profile_image.url }}" alt="프로필 이미지" />
                         {% endif %}
                       </div>
                   </div>
@@ -330,15 +342,17 @@
                     {% if forloop.counter <= 2 %}
                     <div class="avatar shadow-md">
                       <div class="w-8">
-                        {% if member.user.profile_image %}
-                        <img src="{{ member.user.profile_image }}" alt="프로필 이미지" />
-                        {% else %}
+                        {% if not assignee.assignee.profile_image %}
                         <div class="h-full flex justify-center items-center bg-base-100">
                           <svg xmlns="http://www.w3.org/2000/svg" class="fill-current w-2/3 h-2/3" viewBox="0 0 448 512">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                               d="M304 128a80 80 0 1 0 -160 0 80 80 0 1 0 160 0zM96 128a128 128 0 1 1 256 0A128 128 0 1 1 96 128zM49.3 464H398.7c-8.9-63.3-63.3-112-129-112H178.3c-65.7 0-120.1 48.7-129 112zM0 482.3C0 383.8 79.8 304 178.3 304h91.4C368.2 304 448 383.8 448 482.3c0 16.4-13.3 29.7-29.7 29.7H29.7C13.3 512 0 498.7 0 482.3z" />
                           </svg>
                         </div>
+                        {% elif 'http' in user.profile_image.url %}
+                        <img src="{{ assignee.assignee.profile_image }}" alt="프로필 이미지" />
+                        {% else %}
+                        <img src="{{ assignee.assignee.profile_image.url }}" alt="프로필 이미지" />
                         {% endif %}
                       </div>
                   </div>


### PR DESCRIPTION
## 1. 원인
  ### (1) todos/study/ 페이지에서 사용자 프로필이 로드되지 않는 현상
    - media 경로가 `media/..`가 아닌 `todos/study/..`로 설정
  
  ### (2) 개인 Todo 화면에서 사용자의 프로필 사진이 있는 경우에도 default 이미지로 출력되는 현상
    - media 경로가 전혀 출력되지 않음
    - `member.user.profile_image`로 잘못 접근

## 2. 수정

  ### (1) 스터디 Todo 페이지에서 'Member' section의 사용자 프로필 로드
    - member.user.profile_image는 http가 있을때 사용
    - member.user.profile_image 대신 member.user.profile_image.url로 변경
  
  ### (2) 개인 Todo 페이지에서 todo 하단의 사용자 프로필 로드
    - assignee.assignee.profile_image로 접근
    - (1)과 같은 형식으로 수정